### PR TITLE
Update svelte and sapper to fix sourcemaps.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1182,6 +1182,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
       "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
+      "dev": true,
       "requires": {
         "no-case": "^2.2.0",
         "upper-case": "^1.1.1"
@@ -1243,6 +1244,7 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.1.tgz",
       "integrity": "sha512-4ZxI6dy4lrY6FHzfiy1aEOXgu4LIsW2MhwG0VBKdcoGoH/XLFgaHSdLTGr4O8Be6A8r3MOphEiI8Gc1n0ecf3g==",
+      "dev": true,
       "requires": {
         "source-map": "~0.6.0"
       }
@@ -1305,7 +1307,8 @@
     "commander": {
       "version": "2.20.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
+      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+      "dev": true
     },
     "common-tags": {
       "version": "1.8.0",
@@ -1935,7 +1938,8 @@
     "he": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true
     },
     "hosted-git-info": {
       "version": "2.7.1",
@@ -1947,6 +1951,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-4.0.0.tgz",
       "integrity": "sha512-aoGxanpFPLg7MkIl/DDFYtb0iWz7jMFGqFhvEDZga6/4QTjneiD8I/NXL1x5aaoCp7FSIT6h/OhykDdPsbtMig==",
+      "dev": true,
       "requires": {
         "camel-case": "^3.0.0",
         "clean-css": "^4.2.1",
@@ -1972,7 +1977,8 @@
     "http-link-header": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/http-link-header/-/http-link-header-1.0.2.tgz",
-      "integrity": "sha512-z6YOZ8ZEnejkcCWlGZzYXNa6i+ZaTfiTg3WhlV/YvnNya3W/RbX1bMVUMTuCrg/DrtTCQxaFCkXCz4FtLpcebg=="
+      "integrity": "sha512-z6YOZ8ZEnejkcCWlGZzYXNa6i+ZaTfiTg3WhlV/YvnNya3W/RbX1bMVUMTuCrg/DrtTCQxaFCkXCz4FtLpcebg==",
+      "dev": true
     },
     "http-signature": {
       "version": "1.2.0",
@@ -2550,7 +2556,8 @@
     "lower-case": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
-      "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw="
+      "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw=",
+      "dev": true
     },
     "magic-string": {
       "version": "0.25.2",
@@ -2665,6 +2672,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
       "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
+      "dev": true,
       "requires": {
         "lower-case": "^1.1.1"
       }
@@ -2845,6 +2853,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
       "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
+      "dev": true,
       "requires": {
         "no-case": "^2.2.0"
       }
@@ -3104,7 +3113,8 @@
     "relateurl": {
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
-      "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk="
+      "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=",
+      "dev": true
     },
     "repeating": {
       "version": "2.0.1",
@@ -3309,15 +3319,24 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sapper": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/sapper/-/sapper-0.27.4.tgz",
-      "integrity": "sha512-BYdiJSiyVguu2FZBbl87mn8KhSu+C8JRl7FurclXbMgpiMW7Yt74HPCcu/hXOubvvZw0kVTnzBlAGJCXZmldnA==",
+      "version": "0.27.8",
+      "resolved": "https://registry.npmjs.org/sapper/-/sapper-0.27.8.tgz",
+      "integrity": "sha512-78K+56yu9nGOEU0B0XjBvNchRuPEv4aHbAKK4D874S4aoapMAkHCT0bHtPK12S3P7JPxvvT8GzHaq/8NetMmbg==",
+      "dev": true,
       "requires": {
         "html-minifier": "^4.0.0",
         "http-link-header": "^1.0.2",
-        "shimport": "^1.0.0",
-        "sourcemap-codec": "^1.4.4",
+        "shimport": "^1.0.1",
+        "sourcemap-codec": "^1.4.6",
         "string-hash": "^1.1.3"
+      },
+      "dependencies": {
+        "sourcemap-codec": {
+          "version": "1.4.6",
+          "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.6.tgz",
+          "integrity": "sha512-1ZooVLYFxC448piVLBbtOxFcXwnymH9oUF8nRd3CuYDVvkRBxRl6pB4Mtas5a4drtL+E8LDgFkQNcgIw6tc8Hg==",
+          "dev": true
+        }
       }
     },
     "semver": {
@@ -3377,9 +3396,10 @@
       }
     },
     "shimport": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/shimport/-/shimport-1.0.0.tgz",
-      "integrity": "sha512-XKd+39voZT1rFR1ct+pr8sFSYAW6IvM3LeF87FrgcGHc/uSZ4GfOZVA42LE5LXFOpTWgmDC5sS8DNDtiV4Vd4Q=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/shimport/-/shimport-1.0.1.tgz",
+      "integrity": "sha512-Imf4gH+8WQmT1GvxS/x79qpmfnE6m50hyN1ucatX+7oMCgmaF8obZWCPIzSUe6+P+YmXM46lkP2pxiV2/lt9Og==",
+      "dev": true
     },
     "signal-exit": {
       "version": "3.0.2",
@@ -3417,7 +3437,8 @@
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
     },
     "source-map-support": {
       "version": "0.5.12",
@@ -3432,7 +3453,8 @@
     "sourcemap-codec": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.4.tgz",
-      "integrity": "sha512-CYAPYdBu34781kLHkaW3m6b/uUSyMOC2R61gcYMWooeuaGtjof86ZA/8T+qVPPt7np1085CR9hmMGrySwEc8Xg=="
+      "integrity": "sha512-CYAPYdBu34781kLHkaW3m6b/uUSyMOC2R61gcYMWooeuaGtjof86ZA/8T+qVPPt7np1085CR9hmMGrySwEc8Xg==",
+      "dev": true
     },
     "spdx-correct": {
       "version": "3.1.0",
@@ -3497,7 +3519,8 @@
     "string-hash": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/string-hash/-/string-hash-1.1.3.tgz",
-      "integrity": "sha1-6Kr8CsGFW0Zmkp7X3RJ1311sgRs="
+      "integrity": "sha1-6Kr8CsGFW0Zmkp7X3RJ1311sgRs=",
+      "dev": true
     },
     "string-width": {
       "version": "1.0.2",
@@ -3561,9 +3584,9 @@
       }
     },
     "svelte": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.5.1.tgz",
-      "integrity": "sha512-iMnuyteFGQ8Yl68G/DHTHY1sLwoAMya1eS0ZOHIm/dqn2etR8WEe8hUAoluLryde4Cft4gvMhtHV3NhE60nBmQ==",
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.12.1.tgz",
+      "integrity": "sha512-t29WJNjHIqfrdMcVXqIyRfgLEaNz7MihKXTpb8qHlbzvf0WyOOIhIlwIGvl6ahJ9+9CLJwz0sjhFNAmPgo8BHg==",
       "dev": true
     },
     "svelte-dev-helper": {
@@ -3700,6 +3723,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
       "integrity": "sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==",
+      "dev": true,
       "requires": {
         "commander": "~2.20.0",
         "source-map": "~0.6.1"
@@ -3754,7 +3778,8 @@
     "upper-case": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
-      "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg="
+      "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg=",
+      "dev": true
     },
     "uri-js": {
       "version": "4.2.2",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "marked": "^0.6.2",
     "node-fetch": "^2.1.2",
     "polka": "^0.5.2",
-    "sapper": "^0.27.4",
     "session-file-store": "^1.2.0",
     "sirv": "^0.4.2"
   },
@@ -39,7 +38,8 @@
     "rollup-plugin-replace": "^2.2.0",
     "rollup-plugin-svelte": "^5.1.0",
     "rollup-plugin-terser": "^5.0.0",
-    "svelte": "^3.5.1",
+    "sapper": "^0.27.8",
+    "svelte": "^3.12.1",
     "svelte-loader": "^2.13.4"
   },
   "now": {


### PR DESCRIPTION
According to #30, sourcemaps weren't working but a recent build of Svelte or Sapper (or both, who knows, not me) fixed them. This would be nice for people cloning and poking around this repo.

Closes #30.