### PR TITLE
fix build script naming

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -21,7 +21,7 @@ npm run dev
 ...then open [localhost:3000](http://localhost:3000). To build and start in prod mode:
 
 ```bash
-npm run sapper
+npm run build
 npm start
 ```
 


### PR DESCRIPTION
sapper doesn't seem to be in the `package.json` `scripts`, I think it was meant to say `build`