### PR TITLE
fixed alt-text overflowing on empty avatars

### DIFF
--- a/src/routes/_components/ArticleList/ArticlePreview.svelte
+++ b/src/routes/_components/ArticleList/ArticlePreview.svelte
@@ -20,6 +20,11 @@
 	}
 </script>
 
+<style>
+.article-meta a img
+  { overflow: hidden; }
+</style>
+
 <div class="article-preview">
 	<div class="article-meta">
 		<a href='/profile/@{article.author.username}'>

--- a/src/routes/article/_ArticleMeta.svelte
+++ b/src/routes/article/_ArticleMeta.svelte
@@ -13,6 +13,11 @@
 	}
 </script>
 
+<style>
+.article-meta a img
+  { overflow: hidden; }
+</style>
+
 <div class="article-meta">
 	<a href='/profile/@{article.author.username}'>
 		<img src={article.author.image} alt={article.author.username} />


### PR DESCRIPTION
currently:
![Screenshot_2020-01-12 Conduit](https://user-images.githubusercontent.com/59403389/72219856-1509bb00-354b-11ea-929a-263d12493a70.png)
