### PR TITLE
404 when user profile isn't found

### DIFF
--- a/src/routes/profile/[user]/[view].svelte
+++ b/src/routes/profile/[user]/[view].svelte
@@ -5,6 +5,12 @@
 		const username = params.user.slice(1);
 
 		const { profile } = await api.get(`profiles/${username}`, user && user.token);
+		if (!profile) {
+			this.error(404, 'Username not found');
+		}
+		if (params.view !== 'favorites') {
+			this.error(404, 'Page not found');
+		}
 		return { profile, favorites: params.view === 'favorites' };
 	}
 </script>

--- a/src/routes/profile/[user]/index.svelte
+++ b/src/routes/profile/[user]/index.svelte
@@ -5,6 +5,9 @@
 		const username = params.user.slice(1);
 
 		const { profile } = await api.get(`profiles/${username}`, user && user.token);
+		if (!profile) {
+			this.error(404, 'Username not found');
+		}
 		return { profile, favorites: params.view === 'favorites' };
 	}
 </script>


### PR DESCRIPTION
It used to 500 with `Cannot read property 'username' of undefined` ([example](https://realworld.svelte.dev/profile/@lasdkfjlskfjlakdjflkjadlfj))