### PR TITLE
update jsconfig.json

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -2,7 +2,7 @@
 	"compilerOptions": {
 		"baseUrl": ".",
 		"paths": {
-			"$app/*": [".svelte-kit/dev/runtime/app/*", ".svelte-kit/build/runtime/app/*"],
+			"$lib": ["src/lib"],
 			"$lib/*": ["src/lib/*"]
 		}
 	},


### PR DESCRIPTION
when you create a new project there's no longer an `$app` alias, but only a `$lib` alias