### PR TITLE
Update save.js

### DIFF
--- a/src/routes/auth/save.js
+++ b/src/routes/auth/save.js
@@ -2,7 +2,7 @@ import * as api from '$lib/api.js';
 import { respond } from './_respond';
 
 export async function post({ request, locals }) {
-	let user = await request.json();
+	const user = await request.json();
 
 	if (!locals.user) {
 		return {

--- a/src/routes/auth/save.js
+++ b/src/routes/auth/save.js
@@ -2,14 +2,13 @@ import * as api from '$lib/api.js';
 import { respond } from './_respond';
 
 export async function post({ request, locals }) {
-	const user = await request.json();
-
 	if (!locals.user) {
 		return {
 			status: 401
 		};
 	}
 
+	const user = await request.json();
 	const { token } = locals.user;
 	const body = await api.put(
 		'user',

--- a/src/routes/auth/save.js
+++ b/src/routes/auth/save.js
@@ -1,7 +1,9 @@
 import * as api from '$lib/api.js';
 import { respond } from './_respond';
 
-export async function post({ body: user, locals }) {
+export async function post({ request, locals }) {
+	let user = await request.json();
+
 	if (!locals.user) {
 		return {
 			status: 401


### PR DESCRIPTION
A PR in SvelteKit introduces a number of breaking changes that

lay the foundation for streaming request/response bodies
enable multipart form handling (including file uploads)
better align SvelteKit with modern platforms that deal with `Request` and `Response` objects natively

Hooks (`handle`, `handleError` and `getSession`) and endpoints previously received a proprietary `Request` object:
```ts
interface Request<Locals = Record<string, any>, Body = unknown> {
  url: URL;
  method: string;
  headers: RequestHeaders;
  rawBody: RawBody;
  params: Record<string, string>;
  body: ParameterizedBody<Body>;
  locals: Locals;
}
```
Instead, they now receive a `RequestEvent`:

```ts
export interface RequestEvent<Locals = Record<string, any>> {
  request: Request; // https://developer.mozilla.org/en-US/docs/Web/API/Request
  url: URL; // https://developer.mozilla.org/en-US/docs/Web/API/URL
  params: Record<string, string>;
  locals: Locals;
}
```
`method` and `headers` are no longer necessary as they exist on the `request` object. (`url` is still provided, since the `URL` object contains conveniences like `url.searchParams.get('foo')`, whereas `request.url` is a string.)

To access the request body use the text/json/arrayBuffer/formData methods, e.g. `body = await request.json()`.
See https://github.com/sveltejs/kit/pull/3384 for details