### PR TITLE
fix #112

### DIFF
--- a/src/routes/article/[slug]/comments.json/+server.js
+++ b/src/routes/article/[slug]/comments.json/+server.js
@@ -20,7 +20,7 @@ export async function POST({ params, request, locals }) {
 	const { comment } = await api.post(
 		`articles/${slug}/comments`,
 		{ comment: { body } },
-		locals.user.token,
+		locals.user.token
 	);
 
 	// for AJAX requests, return the newly created comment

--- a/src/routes/article/[slug]/comments.json/+server.js
+++ b/src/routes/article/[slug]/comments.json/+server.js
@@ -20,12 +20,12 @@ export async function POST({ params, request, locals }) {
 	const { comment } = await api.post(
 		`articles/${slug}/comments`,
 		{ comment: { body } },
-		locals.user.token
+		locals.user.token,
 	);
 
 	// for AJAX requests, return the newly created comment
 	if (request.headers.get('accept') === 'application/json') {
-		throw json(comment, { status: 201 }); // 201 - created
+		return json(comment, { status: 201 }); // 201 - created
 	}
 
 	// for traditional (no-JS) form submissions, redirect

--- a/src/routes/article/[slug]/comments/[id].json/+server.js
+++ b/src/routes/article/[slug]/comments/[id].json/+server.js
@@ -1,3 +1,4 @@
+import { error, json } from '@sveltejs/kit';
 import * as api from '$lib/api.js';
 
 export async function DELETE({ params, locals }) {
@@ -11,4 +12,7 @@ export async function DELETE({ params, locals }) {
 	if (error) {
 		throw (status, { error });
 	}
+
+	// comment was deleted successfully
+	return json({});
 }


### PR DESCRIPTION
This fixes #112. Note that the comments were being deleted upon clicking on the trash icon, but a server error was raised because a `Response` object was expected and none was returned. 

There was also a bug when posting new comments because a `json` was being thrown instead of returned.