### PR TITLE
Fixes undefined variable "profile"

### DIFF
--- a/src/routes/profile/%40[user]/+layout.svelte
+++ b/src/routes/profile/%40[user]/+layout.svelte
@@ -17,7 +17,7 @@
 		const { following, username } = data.profile;
 
 		// optimistic UI
-      data.profile.following = !data.profile.following;
+      	data.profile.following = !data.profile.following;
 
 		const res = await fetch(`/profile/@${username}/follow`, {
 			method: following ? 'delete' : 'post'
@@ -29,7 +29,7 @@
 		// with our optimistic UI for some reason — but only
 		// if the button wasn't re-toggled in the meantime
 		if (token === current_token) {
-          data.profile = result.profile;
+			data.profile = result.profile;
 		}
 	}
 </script>

--- a/src/routes/profile/%40[user]/+layout.svelte
+++ b/src/routes/profile/%40[user]/+layout.svelte
@@ -8,16 +8,16 @@
 	// https://github.com/sveltejs/kit/issues/269
 	$: segments = $page.url.pathname.split('/');
 	$: is_favorites = segments.length === 4 && segments[3] === 'favorites';
-	$: is_user = $session.user && profile.username === $session.user.username;
+	$: is_user = $session.user && data.profile.username === $session.user.username;
 
 	let current_token;
 	async function toggle_following() {
 		const token = (current_token = {});
 
-		const { following, username } = profile;
+		const { following, username } = data.profile;
 
 		// optimistic UI
-		profile.following = !profile.following;
+      data.profile.following = !data.profile.following;
 
 		const res = await fetch(`/profile/@${username}/follow`, {
 			method: following ? 'delete' : 'post'
@@ -29,7 +29,7 @@
 		// with our optimistic UI for some reason — but only
 		// if the button wasn't re-toggled in the meantime
 		if (token === current_token) {
-			profile = result.profile;
+          data.profile = result.profile;
 		}
 	}
 </script>


### PR DESCRIPTION
The load()-function in +page.js returns the "profile"-object referenced as "data" in +layout.svelte, hence it should be referenced as "data.profile" instead of "profile".