### PR TITLE
fix: don't nest `<a>` elements in tag list

### DIFF
--- a/src/lib/ArticleList/ArticlePreview.svelte
+++ b/src/lib/ArticleList/ArticlePreview.svelte
@@ -55,7 +55,7 @@
 		<span>Read more...</span>
 		<ul class="tag-list">
 			{#each article.tagList as tag}
-				<li class="tag-default tag-pill tag-outline"><a href="/?tag={tag}">{tag}</a></li>
+				<li class="tag-default tag-pill tag-outline">{tag}</li>
 			{/each}
 		</ul>
 	</a>


### PR DESCRIPTION
Closes #171. This matches other implementations of the demo.