### PR TITLE
`error()`/`redirect()` fixes

### DIFF
--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -20,7 +20,7 @@ async function send({ method, path, data, token }) {
 		return text ? JSON.parse(text) : {};
 	}
 
-	throw error(res.status);
+	error(res.status);
 }
 
 export function get(path, token) {

--- a/src/routes/article/[slug]/+page.server.js
+++ b/src/routes/article/[slug]/+page.server.js
@@ -17,7 +17,7 @@ export async function load({ locals, params }) {
 /** @type {import('./$types').Actions} */
 export const actions = {
 	createComment: async ({ locals, params, request }) => {
-		if (!locals.user) throw error(401);
+		if (!locals.user) error(401);
 
 		const data = await request.formData();
 
@@ -33,23 +33,23 @@ export const actions = {
 	},
 
 	deleteComment: async ({ locals, params, url }) => {
-		if (!locals.user) throw error(401);
+		if (!locals.user) error(401);
 
 		const id = url.searchParams.get('id');
 		const result = await api.del(`articles/${params.slug}/comments/${id}`, locals.user.token);
 
-		if (result.error) throw error(result.status, result.error);
+		if (result.error) error(result.status, result.error);
 	},
 
 	deleteArticle: async ({ locals, params }) => {
-		if (!locals.user) throw error(401);
+		if (!locals.user) error(401);
 
 		await api.del(`articles/${params.slug}`, locals.user.token);
-		throw redirect(307, '/');
+		redirect(307, '/');
 	},
 
 	toggleFavorite: async ({ locals, params, request }) => {
-		if (!locals.user) throw error(401);
+		if (!locals.user) error(401);
 
 		const data = await request.formData();
 		const favorited = data.get('favorited') !== 'on';
@@ -60,6 +60,6 @@ export const actions = {
 			api.del(`articles/${params.slug}/favorite`, locals.user.token);
 		}
 
-		throw redirect(307, request.headers.get('referer') ?? `/article/${params.slug}`);
+		redirect(307, request.headers.get('referer') ?? `/article/${params.slug}`);
 	}
 };

--- a/src/routes/editor/+page.server.js
+++ b/src/routes/editor/+page.server.js
@@ -1,4 +1,4 @@
-import { redirect, fail } from '@sveltejs/kit';
+import { error, fail, redirect } from '@sveltejs/kit';
 import * as api from '$lib/api.js';
 
 /** @type {import('./$types').PageServerLoad} */

--- a/src/routes/editor/+page.server.js
+++ b/src/routes/editor/+page.server.js
@@ -3,13 +3,13 @@ import * as api from '$lib/api.js';
 
 /** @type {import('./$types').PageServerLoad} */
 export async function load({ locals }) {
-	if (!locals.user) throw redirect(302, `/login`);
+	if (!locals.user) redirect(302, `/login`);
 }
 
 /** @type {import('./$types').Actions} */
 export const actions = {
 	default: async ({ locals, request }) => {
-		if (!locals.user) throw error(401);
+		if (!locals.user) error(401);
 
 		const data = await request.formData();
 
@@ -28,6 +28,6 @@ export const actions = {
 
 		if (result.errors) return fail(400, result);
 
-		throw redirect(303, `/article/${result.article.slug}`);
+		redirect(303, `/article/${result.article.slug}`);
 	}
 };

--- a/src/routes/editor/[slug]/+page.server.js
+++ b/src/routes/editor/[slug]/+page.server.js
@@ -2,7 +2,7 @@ import { redirect } from '@sveltejs/kit';
 import * as api from '$lib/api.js';
 
 export async function load({ locals, params }) {
-	if (!locals.user) throw redirect(302, `/login`);
+	if (!locals.user) redirect(302, `/login`);
 
 	const { article } = await api.get(`articles/${params.slug}`, locals.user.token);
 	return { article };
@@ -11,7 +11,7 @@ export async function load({ locals, params }) {
 /** @type {import('./$types').Actions} */
 export const actions = {
 	default: async ({ locals, params, request }) => {
-		if (!locals.user) throw error(401);
+		if (!locals.user) error(401);
 
 		const data = await request.formData();
 
@@ -28,8 +28,8 @@ export const actions = {
 			locals.user.token
 		);
 
-		if (result.errors) throw error(400, result.errors);
+		if (result.errors) error(400, result.errors);
 
-		throw redirect(303, `/article/${result.article.slug}`);
+		redirect(303, `/article/${result.article.slug}`);
 	}
 };

--- a/src/routes/editor/[slug]/+page.server.js
+++ b/src/routes/editor/[slug]/+page.server.js
@@ -1,4 +1,4 @@
-import { redirect } from '@sveltejs/kit';
+import { error, redirect } from '@sveltejs/kit';
 import * as api from '$lib/api.js';
 
 export async function load({ locals, params }) {

--- a/src/routes/login/+page.server.js
+++ b/src/routes/login/+page.server.js
@@ -3,7 +3,7 @@ import * as api from '$lib/api.js';
 
 /** @type {import('./$types').PageServerLoad} */
 export async function load({ locals }) {
-	if (locals.user) throw redirect(307, '/');
+	if (locals.user) redirect(307, '/');
 }
 
 /** @type {import('./$types').Actions} */
@@ -25,6 +25,6 @@ export const actions = {
 		const value = btoa(JSON.stringify(body.user));
 		cookies.set('jwt', value, { path: '/' });
 
-		throw redirect(307, '/');
+		redirect(307, '/');
 	}
 };

--- a/src/routes/profile/+page.js
+++ b/src/routes/profile/+page.js
@@ -2,5 +2,5 @@ import { redirect } from '@sveltejs/kit';
 
 export async function load({ parent }) {
 	const { user } = await parent();
-	throw redirect(307, user ? `/profile/@${user.username}` : '/login');
+	redirect(307, user ? `/profile/@${user.username}` : '/login');
 }

--- a/src/routes/profile/@[user]/+page.server.js
+++ b/src/routes/profile/@[user]/+page.server.js
@@ -1,5 +1,5 @@
 import * as api from '$lib/api.js';
-import { fail } from '@sveltejs/kit';
+import { error, fail } from '@sveltejs/kit';
 import { get_articles } from './get_articles';
 
 /** @type {import('./$types').PageServerLoad} */

--- a/src/routes/profile/@[user]/+page.server.js
+++ b/src/routes/profile/@[user]/+page.server.js
@@ -11,7 +11,7 @@ export async function load(event) {
 /** @type {import('./$types').Actions} */
 export const actions = {
 	toggleFollow: async ({ locals, params, request }) => {
-		if (!locals.user) throw error(401);
+		if (!locals.user) error(401);
 
 		const data = await request.formData();
 		const following = data.get('following') !== 'on';

--- a/src/routes/register/+page.server.js
+++ b/src/routes/register/+page.server.js
@@ -4,7 +4,7 @@ import * as api from '$lib/api.js';
 /** @type {import('./$types').PageServerLoad} */
 export async function load({ parent }) {
 	const { user } = await parent();
-	if (user) throw redirect(307, '/');
+	if (user) redirect(307, '/');
 }
 
 /** @type {import('./$types').Actions} */
@@ -27,6 +27,6 @@ export const actions = {
 		const value = btoa(JSON.stringify(body.user));
 		cookies.set('jwt', value, { path: '/' });
 
-		throw redirect(307, '/');
+		redirect(307, '/');
 	}
 };

--- a/src/routes/settings/+page.server.js
+++ b/src/routes/settings/+page.server.js
@@ -2,7 +2,7 @@ import { fail, redirect } from '@sveltejs/kit';
 import * as api from '$lib/api.js';
 
 export function load({ locals }) {
-	if (!locals.user) throw redirect(302, '/login');
+	if (!locals.user) redirect(302, '/login');
 }
 
 /** @type {import('./$types').Actions} */
@@ -13,7 +13,7 @@ export const actions = {
 	},
 
 	save: async ({ cookies, locals, request }) => {
-		if (!locals.user) throw error(401);
+		if (!locals.user) error(401);
 
 		const data = await request.formData();
 

--- a/src/routes/settings/+page.server.js
+++ b/src/routes/settings/+page.server.js
@@ -1,4 +1,4 @@
-import { fail, redirect } from '@sveltejs/kit';
+import { error, fail, redirect } from '@sveltejs/kit';
 import * as api from '$lib/api.js';
 
 export function load({ locals }) {


### PR DESCRIPTION
1. They were changed to throw themselves, so the extra `throw` is redundant.
2. `error` was not imported in several files it was used.